### PR TITLE
enhancement(terraform): Configurable path prefix to lookup code

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,7 +27,7 @@ module "cai_sa_analyzer" {
   org_id               = var.org_id
   project_id           = data.google_project.sa_key_usage.project_id
   region               = var.region
-  path_prefix          = "../"
+  path_prefix          = var.code_path_prefix
   bq_location          = var.bq_location
   cai_dataset_id       = var.cai_dataset_id
   key_usage_dataset_id = var.key_usage_dataset_id

--- a/terraform/modules/cai-sa-analyzer/functions.tf
+++ b/terraform/modules/cai-sa-analyzer/functions.tf
@@ -37,7 +37,7 @@ resource "google_storage_bucket" "cai_code_bucket" {
 data "archive_file" "cai_export_zip" {
   type        = "zip"
   output_path = "/tmp/cai-export.zip"
-  source_dir  = "${var.path_prefix}src/cai-export/"
+  source_dir  = var.path_prefix ? "${var.path_prefix}/src/export" : "${path.module}../../../../src/cai-export/"
 }
 
 resource "google_storage_bucket_object" "cai_export_object" {
@@ -83,7 +83,7 @@ resource "google_cloudfunctions2_function" "cai_export_function" {
 data "archive_file" "access_analyzer_zip" {
   type        = "zip"
   output_path = "/tmp/access-analyzer.zip"
-  source_dir  = "${var.path_prefix}/src/access-analyzer/"
+  source_dir  = var.path_prefix ? "${var.path_prefix}/src/access-analyzer" : "${path.module}../../../../src/access-analyzer/"
 }
 
 resource "google_storage_bucket_object" "access_analyzer_object" {

--- a/terraform/modules/cai-sa-analyzer/variables.tf
+++ b/terraform/modules/cai-sa-analyzer/variables.tf
@@ -92,9 +92,12 @@ variable "custom_cai_org_role" {
 # Cloud Functions
 
 variable "path_prefix" {
-  description = "Path prefix from terraform directory to cai-sa-analyzer submodule"
-  type        = string
-  default     = "."
+  description = <<EOT
+Path prefix to the folder where src/cai-export and src/access-analyzer are located.
+Leave empty if the code can be found in its default location. Use "." for a relative path.
+EOT
+  type        = optional(string)
+  default     = ""
 }
 
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,6 +38,15 @@ variable "sa_key_schedule" {
   default     = "0 5 * * *"
 }
 
+variable "code_path_prefix" {
+  description = <<EOT
+Path prefix to the folder where src/cai-export and src/access-analyzer are located.
+Leave empty if the code can be found in its default location. Use "." for a relative path.
+EOT
+  type        = string
+  default     = ""
+}
+
 
 # BigQuery
 


### PR DESCRIPTION
Terraform will now by default look at the default path. This also allows this module to be referenced as follows:
```terraform
module "cai-export" {
  source = "github.com/GoogleCloudPlatform/migrate-from-service-account-keys//terraform

  ...
}
```
I need to test a bit more before I can verify everything works, so I'll add this to the README.md in a separate PR.